### PR TITLE
Fix static linking.

### DIFF
--- a/guetzli.make
+++ b/guetzli.make
@@ -24,7 +24,7 @@ ifeq ($(config),release)
   ALL_RESFLAGS += $(RESFLAGS) $(DEFINES) $(INCLUDES)
   LIBS +=
   LDDEPS +=
-  ALL_LDFLAGS += $(LDFLAGS) -s -lpng -lgflags_nothreads
+  ALL_LDFLAGS += $(LDFLAGS) -s -lpng -lgflags_nothreads -lz
   LINKCMD = $(CXX) -o "$@" $(OBJECTS) $(RESOURCES) $(ALL_LDFLAGS) $(LIBS)
   define PREBUILDCMDS
   endef
@@ -51,7 +51,7 @@ ifeq ($(config),debug)
   ALL_RESFLAGS += $(RESFLAGS) $(DEFINES) $(INCLUDES)
   LIBS +=
   LDDEPS +=
-  ALL_LDFLAGS += $(LDFLAGS) -lpng -lgflags_nothreads
+  ALL_LDFLAGS += $(LDFLAGS) -lpng -lgflags_nothreads -lz
   LINKCMD = $(CXX) -o "$@" $(OBJECTS) $(RESOURCES) $(ALL_LDFLAGS) $(LIBS)
   define PREBUILDCMDS
   endef

--- a/guetzli.vcxproj
+++ b/guetzli.vcxproj
@@ -70,6 +70,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
     </Link>
   </ItemDefinitionGroup>
@@ -85,6 +86,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
     </Link>
   </ItemDefinitionGroup>

--- a/premake5.lua
+++ b/premake5.lua
@@ -13,7 +13,9 @@ workspace "guetzli"
     language "C++"
     includedirs { ".", "third_party/butteraugli" }
     filter "action:gmake"
-      linkoptions { "-lpng", "-lgflags_nothreads" }
+      linkoptions { "-lpng", "-lgflags_nothreads", "-lz" }
+    filter "action:vs*"
+      links { "shlwapi" }
     filter {}
     -- This should work with gflags 2.x. The gflags namespace is absent in
     -- gflags-2.0, which is the version in Ubuntu Trusty package repository.


### PR DESCRIPTION
Make static linking possible when using Visual Studio and when using GNU
Make. To link statically with GNU Make, do:

make LDFLAGS=-static ...other arguments...

To link statically with VS 2015, install static versions of
dependencies:

vcpkg install libpng:x86-windows-static gflags:x86-windows-static

change the runtime library setting in the project from /MD to /MT,
attempt to build with VS and then run:

c:\path\to\msbuild /p:Configuration=Release /p:VcpkgTriplet=x86-windows-static /p:VcpkgEnabled=true