### PR TITLE
Update png_archive to latest version in 1.2.x branch

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,9 +6,9 @@ workspace(name = "guetzli")
 new_http_archive(
     name = "png_archive",
     build_file = "png.BUILD",
-    sha256 = "c35bcc6387495ee6e757507a68ba036d38ad05b415c2553b3debe2a57647a692",
-    strip_prefix = "libpng-1.2.53",
-    url = "http://github.com/glennrp/libpng/archive/v1.2.53.zip",
+    sha256 = "a941dc09ca00148fe7aaf4ecdd6a67579c293678ed1e1cf633b5ffc02f4f8cf7",
+    strip_prefix = "libpng-1.2.57",
+    url = "http://github.com/glennrp/libpng/archive/v1.2.57.zip",
 )
 
 new_http_archive(


### PR DESCRIPTION
Contain security fix only so nothing should break.Would you consider upgrading to 1.6.x later on?

More info : https://sourceforge.net/p/libpng/news/