### PR TITLE
Prevent complier warning (static const char * - defined but not used)

### DIFF
--- a/guetzli/stats.h
+++ b/guetzli/stats.h
@@ -26,9 +26,9 @@
 
 namespace guetzli {
 
-static const char* kNumItersCnt = "number of iterations";
-static const char* kNumItersUpCnt = "number of iterations up";
-static const char* kNumItersDownCnt = "number of iterations down";
+static const char* const  kNumItersCnt = "number of iterations";
+static const char* const kNumItersUpCnt = "number of iterations up";
+static const char* const kNumItersDownCnt = "number of iterations down";
 
 struct ProcessStats {
   ProcessStats() {}


### PR DESCRIPTION
While compiling you bazel show  warnings such as  
`guetzli::kNumItersCnt' defined but not used`

I am just starting to learn C++ so i though to fix the low hanging fruits first