### PR TITLE
Fix compilation error on Mac.

### DIFF
--- a/guetzli/guetzli.cc
+++ b/guetzli/guetzli.cc
@@ -20,6 +20,7 @@
 #include <memory>
 #include <string>
 #include <string.h>
+#include <unistd.h>
 #include "gflags/gflags.h"
 #include "png.h"
 #include "guetzli/processor.h"


### PR DESCRIPTION
_exit is declared in unistd.h