### PR TITLE
Add docs for OSX install

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ sequential (nonprogressive) JPEGs due to faster decompression speeds they offer.
     *   Using MacPorts: `port install libpng gflags` (You may need to use `sudo`).
 4.  Run the following command to build the binary in `bin/Release/guetzli`.
     *   If you installed using Homebrew simply use `make`
-    *   If you installed using Macports use `CFLAGS='-I/opt/local/include' LDFLAGS='-L/opt/local/lib'`
+    *   If you installed using Macports use `CFLAGS='-I/opt/local/include' LDFLAGS='-L/opt/local/lib' make`
 
 ## With Bazel
 

--- a/README.md
+++ b/README.md
@@ -37,17 +37,22 @@ sequential (nonprogressive) JPEGs due to faster decompression speeds they offer.
 
 ## On macOS
 
+To install using [Homebrew](https://brew.sh/):
+1. Install [Homebrew](https://brew.sh/)
+2. `brew install guetzli`
+
+To install using the repository:
 1.  Get a copy of the source code, either by cloning this repository, or by
     downloading an
     [archive](https://github.com/google/guetzli/archive/master.zip) and
     unpacking it.
 2.  Install [Homebrew](https://brew.sh/) or [MacPorts](https://www.macports.org/)
-3.  Install `libpng` and `gflags` 
-    *   Using Homebrew: `brew install libpng gflags`.
-    *   Using MacPorts: `port install libpng gflags` (You may need to use `sudo`).
+3.  Install `libpng` and `gflags`
+    *   Using [Homebrew](https://brew.sh/): `brew install libpng gflags`.
+    *   Using [MacPorts](https://www.macports.org/): `port install libpng gflags` (You may need to use `sudo`).
 4.  Run the following command to build the binary in `bin/Release/guetzli`.
-    *   If you installed using Homebrew simply use `make`
-    *   If you installed using Macports use `CFLAGS='-I/opt/local/include' LDFLAGS='-L/opt/local/lib' make`
+    *   If you installed using [Homebrew](https://brew.sh/) simply use `make`
+    *   If you installed using [MacPorts](https://www.macports.org/) use `CFLAGS='-I/opt/local/include' LDFLAGS='-L/opt/local/lib' make`
 
 ## With Bazel
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ sequential (nonprogressive) JPEGs due to faster decompression speeds they offer.
     documentation](https://github.com/Microsoft/vcpkg/blob/master/docs/EXAMPLES.md#example-1-2).
 5.  Open the Visual Studio project enclosed in the repository and build it.
 
+## On OSX
+
+1.  Get a copy of the source code, either by cloning this repository, or by
+    downloading an
+    [archive](https://github.com/google/guetzli/archive/master.zip) and
+    unpacking it.
+2.  Install [Homebrew](https://brew.sh/)
+3.  Install `libpng` and `gflags` using brew: `brew install libpng gflags`.
+4.  Run `make` and expect the binary to be created in `bin/Release/guetzli`.
+
 ## With Bazel
 
 There's also a [Bazel](https://bazel.build) build configuration provided. If you

--- a/README.md
+++ b/README.md
@@ -35,15 +35,19 @@ sequential (nonprogressive) JPEGs due to faster decompression speeds they offer.
     documentation](https://github.com/Microsoft/vcpkg/blob/master/docs/EXAMPLES.md#example-1-2).
 5.  Open the Visual Studio project enclosed in the repository and build it.
 
-## On OSX
+## On macOS
 
 1.  Get a copy of the source code, either by cloning this repository, or by
     downloading an
     [archive](https://github.com/google/guetzli/archive/master.zip) and
     unpacking it.
-2.  Install [Homebrew](https://brew.sh/)
-3.  Install `libpng` and `gflags` using brew: `brew install libpng gflags`.
-4.  Run `make` and expect the binary to be created in `bin/Release/guetzli`.
+2.  Install [Homebrew](https://brew.sh/) or [MacPorts](https://www.macports.org/)
+3.  Install `libpng` and `gflags` 
+    *   Using Homebrew: `brew install libpng gflags`.
+    *   Using MacPorts: `port install libpng gflags` (You may need to use `sudo`).
+4.  Run the following command to build the binary in `bin/Release/guetzli`.
+    *   If you installed using Homebrew simply use `make`
+    *   If you installed using Macports use `CFLAGS='-I/opt/local/include' LDFLAGS='-L/opt/local/lib'`
 
 ## With Bazel
 


### PR DESCRIPTION
Adds documentation on how to install and run `guetzli` on OSX.