### PR TITLE
Fix compilation error on FreeBSD

### DIFF
--- a/guetzli/output_image.cc
+++ b/guetzli/output_image.cc
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <cmath>
+#include <cstdlib>
 
 #include "guetzli/idct.h"
 #include "guetzli/color_transform.h"


### PR DESCRIPTION
exit() is declared in cstdlib.