### PR TITLE
Remove unistd.h import breaking Windows build

### DIFF
--- a/guetzli/guetzli.cc
+++ b/guetzli/guetzli.cc
@@ -183,7 +183,7 @@ void WriteFileOrDie(FILE* f, const std::string& contents) {
 void TerminateHandler() {
   fprintf(stderr, "Unhandled exception. Most likely insufficient memory available.\n"
           "Make sure that there is 300MB/MPix of memory available.\n");
-  _exit(1);
+  exit(1);
 }
 
 }  // namespace

--- a/guetzli/guetzli.cc
+++ b/guetzli/guetzli.cc
@@ -20,7 +20,6 @@
 #include <memory>
 #include <string>
 #include <string.h>
-#include <unistd.h>
 #include "gflags/gflags.h"
 #include "png.h"
 #include "guetzli/processor.h"


### PR DESCRIPTION
Windows doesn't expose `unistd.h` so this causes errors compiling guetzli

I'm running a Linux VM right now to make sure nothing relies on importing `unistd.h` in this file. If something does, I guess I'll have to add a `#ifdef`