### PR TITLE
Better error message on reading JPEG YUV422 format

### DIFF
--- a/guetzli/jpeg_data.cc
+++ b/guetzli/jpeg_data.cc
@@ -33,6 +33,18 @@ bool JPEGData::Is420() const {
           components[2].v_samp_factor == 1);
 }
 
+bool JPEGData::Is422() const {
+  return (components.size() == 3 &&
+          max_h_samp_factor == 2 &&
+          max_v_samp_factor == 1 &&
+          components[0].h_samp_factor == 2 &&
+          components[0].v_samp_factor == 1 &&
+          components[1].h_samp_factor == 1 &&
+          components[1].v_samp_factor == 1 &&
+          components[2].h_samp_factor == 1 &&
+          components[2].v_samp_factor == 1);
+}
+
 bool JPEGData::Is444() const {
   return (components.size() == 3 &&
           max_h_samp_factor == 1 &&

--- a/guetzli/jpeg_data.h
+++ b/guetzli/jpeg_data.h
@@ -179,6 +179,7 @@ struct JPEGData {
                error(JPEG_OK) {}
 
   bool Is420() const;
+  bool Is422() const;
   bool Is444() const;
 
   int width;

--- a/guetzli/processor.cc
+++ b/guetzli/processor.cc
@@ -841,6 +841,12 @@ bool Process(const Params& params, ProcessStats* stats,
     fprintf(stderr, "Can't read jpg data from input file\n");
     return false;
   }
+  if (jpg.Is422()) {
+    fprintf(stderr, 
+            "JPEG input file (YUV422) is not supported yet.\n"
+            "Please first convert it to PNG as a workaround.\n");
+    return false;
+  }
   std::vector<uint8_t> rgb = DecodeJpegToRGB(jpg);
   if (rgb.empty()) {
     fprintf(stderr, "Invalid input JPEG file\n");


### PR DESCRIPTION
If YUV422 input format will not be supported in the short term. It would be better to print an error message to guide users like the following,

JPEG input file (YUV422) is not supported yet.
Please first convert it to PNG as a workaround.
Guetzli processing failed