### PR TITLE
Remove the gflags dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ sequential (nonprogressive) JPEGs due to faster decompression speeds they offer.
     downloading an
     [archive](https://github.com/google/guetzli/archive/master.zip) and
     unpacking it.
-2.  Install [libpng](http://www.libpng.org/pub/png/libpng.html) and
-    [gflags](https://github.com/gflags/gflags). If using your operating system
+2.  Install [libpng](http://www.libpng.org/pub/png/libpng.html).
+    If using your operating system
     package manager, install development versions of the packages if the
     distinction exists.
-    *   On Ubuntu, do `apt-get install libpng-dev libgflags-dev`.
-    *   On Arch Linux, do `pacman -S libpng gflags`.
+    *   On Ubuntu, do `apt-get install libpng-dev`.
+    *   On Arch Linux, do `pacman -S libpng`.
 3.  Run `make` and expect the binary to be created in `bin/Release/guetzli`.
 
 ## On Windows
@@ -29,7 +29,7 @@ sequential (nonprogressive) JPEGs due to faster decompression speeds they offer.
     unpacking it.
 2.  Install [Visual Studio 2015](https://www.visualstudio.com) and
     [vcpkg](https://github.com/Microsoft/vcpkg)
-3.  Install `libpng` and `gflags` using vcpkg: `.\vcpkg install libpng gflags`.
+3.  Install `libpng` using vcpkg: `.\vcpkg install `libpng.
 4.  Cause the installed packages to be available system-wide: `.\vcpkg integrate
     install`. If you prefer not to do this, refer to [vcpkg's
     documentation](https://github.com/Microsoft/vcpkg/blob/master/docs/EXAMPLES.md#example-1-2).
@@ -47,9 +47,9 @@ To install using the repository:
     [archive](https://github.com/google/guetzli/archive/master.zip) and
     unpacking it.
 2.  Install [Homebrew](https://brew.sh/) or [MacPorts](https://www.macports.org/)
-3.  Install `libpng` and `gflags`
-    *   Using [Homebrew](https://brew.sh/): `brew install libpng gflags`.
-    *   Using [MacPorts](https://www.macports.org/): `port install libpng gflags` (You may need to use `sudo`).
+3.  Install `libpng`
+    *   Using [Homebrew](https://brew.sh/): `brew install libpng`.
+    *   Using [MacPorts](https://www.macports.org/): `port install libpng` (You may need to use `sudo`).
 4.  Run the following command to build the binary in `bin/Release/guetzli`.
     *   If you installed using [Homebrew](https://brew.sh/) simply use `make`
     *   If you installed using [MacPorts](https://www.macports.org/) use `CFLAGS='-I/opt/local/include' LDFLAGS='-L/opt/local/lib' make`

--- a/guetzli.make
+++ b/guetzli.make
@@ -19,12 +19,12 @@ ifeq ($(config),release)
   INCLUDES += -I. -Ithird_party/butteraugli
   FORCE_INCLUDE +=
   ALL_CPPFLAGS += $(CPPFLAGS) -MMD -MP $(DEFINES) $(INCLUDES)
-  ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -O3 -g `pkg-config --silence-errors --cflags libpng libgflags || pkg-config --cflags libpng gflags`
-  ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -O3 -g -std=c++11 `pkg-config --silence-errors --cflags libpng libgflags || pkg-config --cflags libpng gflags`
+  ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -O3 -g `pkg-config --cflags libpng`
+  ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -O3 -g -std=c++11 `pkg-config --cflags libpng`
   ALL_RESFLAGS += $(RESFLAGS) $(DEFINES) $(INCLUDES)
   LIBS +=
   LDDEPS +=
-  ALL_LDFLAGS += $(LDFLAGS) `pkg-config --silence-errors --libs libpng libgflags || pkg-config --libs libpng gflags`
+  ALL_LDFLAGS += $(LDFLAGS) `pkg-config --libs libpng`
   LINKCMD = $(CXX) -o "$@" $(OBJECTS) $(RESOURCES) $(ALL_LDFLAGS) $(LIBS)
   define PREBUILDCMDS
   endef
@@ -46,12 +46,12 @@ ifeq ($(config),debug)
   INCLUDES += -I. -Ithird_party/butteraugli
   FORCE_INCLUDE +=
   ALL_CPPFLAGS += $(CPPFLAGS) -MMD -MP $(DEFINES) $(INCLUDES)
-  ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -g `pkg-config --silence-errors --cflags libpng libgflags || pkg-config --cflags libpng gflags`
-  ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -g -std=c++11 `pkg-config --silence-errors --cflags libpng libgflags || pkg-config --cflags libpng gflags`
+  ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -g `pkg-config --cflags libpng`
+  ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -g -std=c++11 `pkg-config --cflags libpng`
   ALL_RESFLAGS += $(RESFLAGS) $(DEFINES) $(INCLUDES)
   LIBS +=
   LDDEPS +=
-  ALL_LDFLAGS += $(LDFLAGS) `pkg-config --silence-errors --libs libpng libgflags || pkg-config --libs libpng gflags`
+  ALL_LDFLAGS += $(LDFLAGS) `pkg-config --libs libpng`
   LINKCMD = $(CXX) -o "$@" $(OBJECTS) $(RESOURCES) $(ALL_LDFLAGS) $(LIBS)
   define PREBUILDCMDS
   endef

--- a/premake5.lua
+++ b/premake5.lua
@@ -20,8 +20,8 @@ workspace "guetzli"
     flags "C++11"
     includedirs { ".", "third_party/butteraugli" }
     filter "action:gmake"
-      linkoptions { "`pkg-config --silence-errors --libs libpng libgflags || pkg-config --libs libpng gflags`" }
-      buildoptions { "`pkg-config --silence-errors --cflags libpng libgflags || pkg-config --cflags libpng gflags`" }
+      linkoptions { "`pkg-config --libs libpng`" }
+      buildoptions { "`pkg-config --cflags libpng`" }
     filter "action:vs*"
       links { "shlwapi" }
     filter "platforms:x86"


### PR DESCRIPTION
It seems easier to parse the flags manually (no getopt, because Visual
Studio environment is not POSIX) than to find a way to use gflags on all
the platforms people compile Guetzli on.