### PR TITLE
Color profiles & better documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ have Bazel installed, you can also compile Guetzli by running `bazel build -c op
 **Note:** Guetzli uses a large amount of memory. You should provide 300MB of
 memory per 1MPix of the input image.
 
+**Note:** Guetzli uses a significant amount of CPU time. You should count on
+using about 1 minute of CPU per 1 MPix of input image.
+
 To try out Guetzli you need to [build](#building) or
 [download](https://github.com/google/guetzli/releases) the Guetzli binary. The
 binary reads a PNG or JPEG image and creates an optimized JPEG image:
@@ -73,8 +76,9 @@ guetzli [--quality Q] [--verbose] original.png output.jpg
 guetzli [--quality Q] [--verbose] original.jpg output.jpg
 ```
 
-Note that Guetzli is designed to work on high quality images (e.g. that haven't
-been already compressed with other JPEG encoders). While it will work on other
+Note that Guetzli is designed to work on high quality images. You should always
+prefer providing uncompressed input images (e.g. that haven't been already
+compressed with any JPEG encoders, including Guetzli). While it will work on other
 images too, results will be poorer. You can try compressing an enclosed [sample
 high quality
 image](https://github.com/google/guetzli/releases/download/v0/bees.png).

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ memory per 1MPix of the input image.
 **Note:** Guetzli uses a significant amount of CPU time. You should count on
 using about 1 minute of CPU per 1 MPix of input image.
 
+**Note:** Guetzli assumes that input is in **sRGB profile** with a **gamma of
+2.2**. Guetzli will ignore any color-profile metadata in the image.
+
 To try out Guetzli you need to [build](#building) or
 [download](https://github.com/google/guetzli/releases) the Guetzli binary. The
 binary reads a PNG or JPEG image and creates an optimized JPEG image:

--- a/guetzli/processor.cc
+++ b/guetzli/processor.cc
@@ -795,12 +795,10 @@ bool Processor::ProcessJpegData(const Params& params, const JPEGData& jpg_in,
   for (int downsample = force_420; downsample <= try_420; ++downsample) {
     OutputImage img(jpg.width, jpg.height);
     img.CopyFromJpegData(jpg);
-    JPEGData tmp_jpg;
+    JPEGData tmp_jpg = jpg;
     if (downsample) {
       DownsampleImage(&img);
       img.SaveToJpegData(&tmp_jpg);
-    } else {
-      tmp_jpg = jpg;
     }
     int best_q[3][kDCTBlockSize];
     memcpy(best_q, q_in, sizeof(best_q));

--- a/guetzli/processor.h
+++ b/guetzli/processor.h
@@ -28,7 +28,7 @@ namespace guetzli {
 
 struct Params {
   float butteraugli_target = 1.0;
-  bool clear_metadata = false;
+  bool clear_metadata = true;
   bool try_420 = false;
   bool force_420 = false;
   bool use_silver_screen = false;


### PR DESCRIPTION
Consistently handle color profiles & metadata: always strip. This is not uncommon behaviour for JPEG optimizing tools.

Document that Guetzli should not be run on the same image multiple times.