### PR TITLE
Remove gflags dependency from Bazel build.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -20,14 +20,8 @@ cc_library(
 cc_binary(
     name = "guetzli",
     srcs = ["guetzli/guetzli.cc"],
-    linkopts = [
-        # TODO(robryk): Remove once https://github.com/gflags/gflags/issues/176
-        # is fixed
-        "-lpthread",
-    ],
     deps = [
         ":guetzli_lib",
-        "//external:gflags",
         "@png_archive//:png",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,17 +19,6 @@ new_http_archive(
     url = "http://zlib.net/fossils/zlib-1.2.10.tar.gz",
 )
 
-git_repository(
-    name = "gflags_git",
-    commit = "cce68f0c9c5d054017425e6e6fd54f696d36e8ee",
-    remote = "https://github.com/gflags/gflags.git",
-)
-
-bind(
-    name = "gflags",
-    actual = "@gflags_git//:gflags",
-)
-
 local_repository(
     name = "butteraugli",
     path = "third_party/butteraugli/",


### PR DESCRIPTION
This was forgotten back in #97.