### PR TITLE
Updated Readme.md to make quality parameter better documented.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,10 @@ high quality
 image](https://github.com/google/guetzli/releases/download/v0/bees.png).
 
 You can pass a `--quality Q` parameter to set quality in units equivalent to
-libjpeg quality. You can also pass a `--verbose` flag to see a trace of encoding
+libjpeg quality (0 - 100). Quality is currently limited to numbers greater than
+83 and require modifying the code to go bellow the set threshold.
+
+You can also pass a `--verbose` flag to see a trace of encoding
 attempts made.
 
 Please note that JPEG images do not support alpha channel (transparency). If the


### PR DESCRIPTION
Added example of numbers that can be used for quality parameter and explained the current limit of numbers above the 83% quality threshold.

"equivalent to libjpeg quality" does not have inherent meaning to users without the context of the documentation.