### PR TITLE
Reduce memory usage of guetzli.

### DIFF
--- a/guetzli/guetzli.cc
+++ b/guetzli/guetzli.cc
@@ -34,7 +34,7 @@ constexpr int kDefaultJPEGQuality = 95;
 
 // An upper estimate of memory usage of Guetzli. The bound is
 // max(kLowerMemusaeMB * 1<<20, pixel_count * kBytesPerPixel)
-constexpr int kBytesPerPixel = 300;
+constexpr int kBytesPerPixel = 200;
 constexpr int kLowestMemusageMB = 100; // in MB
 
 constexpr int kDefaultMemlimitMB = 6000; // in MB

--- a/guetzli/processor.cc
+++ b/guetzli/processor.cc
@@ -585,7 +585,6 @@ void Processor::SelectFrequencyMasking(const JPEGData& jpg, OutputImage* img,
 
   std::vector<float> max_block_error(num_blocks);
   std::vector<int> last_indexes(num_blocks);
-  std::vector<float> distmap(width * height);
 
   bool first_up_iter = true;
   for (int direction : {1, -1}) {
@@ -604,6 +603,10 @@ void Processor::SelectFrequencyMasking(const JPEGData& jpg, OutputImage* img,
       std::vector<float> block_weight;
       for (int rblock = 1; rblock <= 4; ++rblock) {
         block_weight = std::vector<float>(num_blocks);
+        std::vector<float> distmap(width * height);
+        if (!first_up_iter) {
+          distmap = comparator_->distmap();
+        }
         comparator_->ComputeBlockErrorAdjustmentWeights(
             direction, rblock, target_mul, factor_x, factor_y, distmap,
             &block_weight);
@@ -733,7 +736,6 @@ void Processor::SelectFrequencyMasking(const JPEGData& jpg, OutputImage* img,
                   100.0 - (100.0 * est_jpg_size) / encoded_jpg.size());
       comparator_->Compare(*img);
       MaybeOutput(encoded_jpg);
-      distmap = comparator_->distmap();
       prev_size = est_jpg_size;
     }
   }

--- a/guetzli/processor.cc
+++ b/guetzli/processor.cc
@@ -291,10 +291,12 @@ QuantData Processor::TryQuantMatrix(const JPEGData& jpg_in,
   OutputImage img(jpg_in.width, jpg_in.height);
   img.CopyFromJpegData(jpg_in);
   img.ApplyGlobalQuantization(data.q);
-  JPEGData jpg_out = jpg_in;
-  img.SaveToJpegData(&jpg_out);
   std::string encoded_jpg;
-  OutputJpeg(jpg_out, &encoded_jpg);
+  {
+    JPEGData jpg_out = jpg_in;
+    img.SaveToJpegData(&jpg_out);
+    OutputJpeg(jpg_out, &encoded_jpg);
+  }
   GUETZLI_LOG(stats_, "Iter %2d: %s quantization matrix:\n",
               stats_->counters[kNumItersCnt] + 1,
               img.FrameTypeStr().c_str());
@@ -711,10 +713,12 @@ void Processor::SelectFrequencyMasking(const JPEGData& jpg, OutputImage* img,
 
       ++stats_->counters[kNumItersCnt];
       ++stats_->counters[direction > 0 ? kNumItersUpCnt : kNumItersDownCnt];
-      JPEGData jpg_out = jpg;
-      img->SaveToJpegData(&jpg_out);
       std::string encoded_jpg;
-      OutputJpeg(jpg_out, &encoded_jpg);
+      {
+        JPEGData jpg_out = jpg;
+        img->SaveToJpegData(&jpg_out);
+        OutputJpeg(jpg_out, &encoded_jpg);
+      }
       GUETZLI_LOG(stats_,
                   "Iter %2d: %s(%d) %s Coeffs[%d/%zd] "
                   "Blocks[%zd/%d/%d] ValThres[%.4f] Out[%7zd] EstErr[%.2f%%]",


### PR DESCRIPTION
This PR continues to address #11 

Peak memory usage of the ~1MP station.png file from the test corpus went from 210 MiB to 161 MiB.