### PR TITLE
Add initial CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.0.0)
+project(guetzli C CXX)
+
+include(CheckCXXCompilerFlag)
+
+find_package(PNG REQUIRED)
+
+include_directories("${PROJECT_SOURCE_DIR}" "${PNG_INCLUDE_DIRS}" "third_party/butteraugli")
+
+CHECK_CXX_COMPILER_FLAG("-std=c++11" GUETZLI_COMPILER_HAS_C11_FLAG)
+if (GUETZLI_COMPILER_HAS_C11_FLAG)
+  list(APPEND CMAKE_CXX_FLAGS "-std=c++11")
+endif()
+
+add_subdirectory(third_party)
+add_subdirectory(guetzli)

--- a/guetzli/CMakeLists.txt
+++ b/guetzli/CMakeLists.txt
@@ -1,0 +1,27 @@
+set(sources
+  butteraugli_comparator.cc
+  dct_double.cc
+  debug_print.cc
+  entropy_encode.cc
+  fdct.cc
+  gamma_correct.cc
+  guetzli.cc
+  idct.cc
+  jpeg_data.cc
+  jpeg_data_decoder.cc
+  jpeg_data_encoder.cc
+  jpeg_data_reader.cc
+  jpeg_data_writer.cc
+  jpeg_huffman_decode.cc
+  output_image.cc
+  preprocess_downsample.cc
+  processor.cc
+  quality.cc
+  quantize.cc
+  score.cc)
+
+add_executable(guetzli ${sources})
+target_link_libraries(guetzli ${PNG_LIBRARY} butteraugli)
+
+add_library(guetzli_static STATIC ${sources})
+target_link_libraries(guetzli ${PNG_LIBRARY} butteraugli)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(butteraugli)

--- a/third_party/butteraugli/CMakeLists.txt
+++ b/third_party/butteraugli/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(butteraugli)

--- a/third_party/butteraugli/butteraugli/CMakeLists.txt
+++ b/third_party/butteraugli/butteraugli/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_library(butteraugli
+    butteraugli.cc)


### PR DESCRIPTION
Work on #134

### How to use (Windows)
```
cmake -G "Ninja" -DCMAKE_TOOLCHAIN_FILE=C:/Users/hughb/Documents/GitHub/vcpkg/scripts/buildsystems/vcpkg.cmake
ninja
```

## How to use (Linux/macos)

```
cmake -G "Ninja"
ninja
```

This has almost identical behaviour to the `make` build system right now

## Details
- The target `guetzli` builds `guetzli.exe`
- The target `guetzli_static` builds `guetzli_static.lib`
- The target `butteraugli` builds `butteraugli.lib`
- View is to remove and replace the existing make/visual studio build system when you guys give the go ahead