### PR TITLE
Reduce guetzli memory usage by 30%

### DIFF
--- a/guetzli/butteraugli_comparator.cc
+++ b/guetzli/butteraugli_comparator.cc
@@ -46,10 +46,6 @@ ButteraugliComparator::ButteraugliComparator(const int width, const int height,
     }
   }
   ::butteraugli::OpsinDynamicsImage(width_, height_, rgb_linear_pregamma_);
-  std::vector<std::vector<float> > dummy(3);
-  ::butteraugli::Mask(rgb_linear_pregamma_, rgb_linear_pregamma_,
-                      width_, height_,
-                      &mask_xyz_, &dummy);
 }
 
 void ButteraugliComparator::Compare(const OutputImage& img) {
@@ -59,6 +55,17 @@ void ButteraugliComparator::Compare(const OutputImage& img) {
   comparator_.DiffmapOpsinDynamicsImage(rgb_linear_pregamma_, rgb, distmap_);
   distance_ = ::butteraugli::ButteraugliScoreFromDiffmap(distmap_);
   GUETZLI_LOG(stats_, " BA[100.00%%] D[%6.4f]", distance_);
+}
+
+void ButteraugliComparator::StartBlockComparisons() {
+  std::vector<std::vector<float> > dummy(3);
+  ::butteraugli::Mask(rgb_linear_pregamma_, rgb_linear_pregamma_,
+                      width_, height_,
+                      &mask_xyz_, &dummy);
+}
+
+void ButteraugliComparator::FinishBlockComparisons() {
+  mask_xyz_.clear();
 }
 
 void ButteraugliComparator::SwitchBlock(int block_x, int block_y,

--- a/guetzli/butteraugli_comparator.cc
+++ b/guetzli/butteraugli_comparator.cc
@@ -25,12 +25,13 @@
 namespace guetzli {
 
 ButteraugliComparator::ButteraugliComparator(const int width, const int height,
-                                             const std::vector<uint8_t>& rgb,
+                                             const std::vector<uint8_t>* rgb,
                                              const float target_distance,
                                              ProcessStats* stats)
     : width_(width),
       height_(height),
       target_distance_(target_distance),
+      rgb_orig_(*rgb),
       rgb_linear_pregamma_(3, std::vector<float>(width_ * height_)),
       comparator_(width_, height_, kButteraugliStep),
       distance_(0.0),
@@ -40,28 +41,8 @@ ButteraugliComparator::ButteraugliComparator(const int width, const int height,
   for (int c = 0; c < 3; ++c) {
     for (int y = 0, ix = 0; y < height_; ++y) {
       for (int x = 0; x < width_; ++x, ++ix) {
-        rgb_linear_pregamma_[c][ix] = lut[rgb[3 * ix + c]];
+        rgb_linear_pregamma_[c][ix] = lut[rgb_orig_[3 * ix + c]];
       }
-    }
-  }
-  const int block_w = (width_ + 7) / 8;
-  const int block_h = (height_ + 7) / 8;
-  const int nblocks = block_w * block_h;
-  per_block_pregamma_.resize(nblocks);
-  for (int block_y = 0, bx = 0; block_y < block_h; ++block_y) {
-    for (int block_x = 0; block_x < block_w; ++block_x, ++bx) {
-      per_block_pregamma_[bx].resize(3, std::vector<float>(kDCTBlockSize));
-      for (int iy = 0, i = 0; iy < 8; ++iy) {
-        for (int ix = 0; ix < 8; ++ix, ++i) {
-          int x = std::min(8 * block_x + ix, width_ - 1);
-          int y = std::min(8 * block_y + iy, height_ - 1);
-          int px = y * width_ + x;
-          for (int c = 0; c < 3; ++c) {
-            per_block_pregamma_[bx][c][i] = rgb_linear_pregamma_[c][px];
-          }
-        }
-      }
-      ::butteraugli::OpsinDynamicsImage(8, 8, per_block_pregamma_[bx]);
     }
   }
   ::butteraugli::OpsinDynamicsImage(width_, height_, rgb_linear_pregamma_);
@@ -80,11 +61,41 @@ void ButteraugliComparator::Compare(const OutputImage& img) {
   GUETZLI_LOG(stats_, " BA[100.00%%] D[%6.4f]", distance_);
 }
 
-double ButteraugliComparator::CompareBlock(
-    const OutputImage& img, int block_x, int block_y) const {
+void ButteraugliComparator::SwitchBlock(int block_x, int block_y,
+                                        int factor_x, int factor_y) {
+  block_x_ = block_x;
+  block_y_ = block_y;
+  factor_x_ = factor_x;
+  factor_y_ = factor_y;
+  per_block_pregamma_.resize(factor_x_ * factor_y_);
+  const double* lut = Srgb8ToLinearTable();
+  for (int off_y = 0, bx = 0; off_y < factor_y_; ++off_y) {
+    for (int off_x = 0; off_x < factor_x_; ++off_x, ++bx) {
+      per_block_pregamma_[bx].resize(3, std::vector<float>(kDCTBlockSize));
+      int block_xx = block_x_ * factor_x_ + off_x;
+      int block_yy = block_y_ * factor_y_ + off_y;
+      for (int iy = 0, i = 0; iy < 8; ++iy) {
+        for (int ix = 0; ix < 8; ++ix, ++i) {
+          int x = std::min(8 * block_xx + ix, width_ - 1);
+          int y = std::min(8 * block_yy + iy, height_ - 1);
+          int px = y * width_ + x;
+          for (int c = 0; c < 3; ++c) {
+            per_block_pregamma_[bx][c][i] = lut[rgb_orig_[3 * px + c]];
+          }
+        }
+      }
+      ::butteraugli::OpsinDynamicsImage(8, 8, per_block_pregamma_[bx]);
+    }
+  }
+}
+
+double ButteraugliComparator::CompareBlock(const OutputImage& img,
+                                           int off_x, int off_y) const {
+  int block_x = block_x_ * factor_x_ + off_x;
+  int block_y = block_y_ * factor_y_ + off_y;
   int xmin = 8 * block_x;
   int ymin = 8 * block_y;
-  int block_ix = block_y * ((width_ + 7) / 8) + block_x;
+  int block_ix = off_y * factor_x_ + off_x;
   const std::vector<std::vector<float> >& rgb0_c =
       per_block_pregamma_[block_ix];
 

--- a/guetzli/butteraugli_comparator.h
+++ b/guetzli/butteraugli_comparator.h
@@ -37,6 +37,9 @@ class ButteraugliComparator : public Comparator {
 
   void Compare(const OutputImage& img) override;
 
+  void StartBlockComparisons() override;
+  void FinishBlockComparisons() override;
+
   void SwitchBlock(int block_x, int block_y,
                    int factor_x, int factor_y) override;
 

--- a/guetzli/butteraugli_comparator.h
+++ b/guetzli/butteraugli_comparator.h
@@ -32,13 +32,16 @@ constexpr int kButteraugliStep = 3;
 class ButteraugliComparator : public Comparator {
  public:
   ButteraugliComparator(const int width, const int height,
-                        const std::vector<uint8_t>& rgb,
+                        const std::vector<uint8_t>* rgb,
                         const float target_distance, ProcessStats* stats);
 
   void Compare(const OutputImage& img) override;
 
+  void SwitchBlock(int block_x, int block_y,
+                   int factor_x, int factor_y) override;
+
   double CompareBlock(const OutputImage& img,
-                      int block_x, int block_y) const override;
+                      int off_x, int off_y) const override;
 
   double ScoreOutputSize(int size) const override;
 
@@ -60,6 +63,11 @@ class ButteraugliComparator : public Comparator {
   const int width_;
   const int height_;
   const float target_distance_;
+  const std::vector<uint8_t>& rgb_orig_;
+  int block_x_;
+  int block_y_;
+  int factor_x_;
+  int factor_y_;
   std::vector<std::vector<float>> rgb_linear_pregamma_;
   std::vector<std::vector<float>> mask_xyz_;
   std::vector<std::vector<std::vector<float>>> per_block_pregamma_;

--- a/guetzli/comparator.h
+++ b/guetzli/comparator.h
@@ -36,6 +36,11 @@ class Comparator {
   // baseline image.
   virtual void Compare(const OutputImage& img) = 0;
 
+  // Must be called before any CompareBlock() calls can be called.
+  virtual void StartBlockComparisons() = 0;
+  // No more CompareBlock() calls can be called after this.
+  virtual void FinishBlockComparisons() = 0;
+
   // Sets the coordinates of the current macro-block for the purpose of
   // CompareBlock() calls.
   virtual void SwitchBlock(int block_x, int block_y,

--- a/guetzli/comparator.h
+++ b/guetzli/comparator.h
@@ -36,11 +36,17 @@ class Comparator {
   // baseline image.
   virtual void Compare(const OutputImage& img) = 0;
 
-  // Compares an 8x8 block of the baseline image with the same block of img and
-  // returns the resulting per-block distance. The interpretation of the
-  // returned distance depends on the comparator used.
+  // Sets the coordinates of the current macro-block for the purpose of
+  // CompareBlock() calls.
+  virtual void SwitchBlock(int block_x, int block_y,
+                           int factor_x, int factor_y) = 0;
+
+  // Compares the 8x8 block with offsets (off_x, off_y) within the current
+  // macro-block of the baseline image with the same block of img and returns
+  // the resulting per-block distance. The interpretation of the returned
+  // distance depends on the comparator used.
   virtual double CompareBlock(const OutputImage& img,
-                              int block_x, int block_y) const = 0;
+                              int off_x, int off_y) const = 0;
 
   // Returns the combined score of the output image in the last Compare() call
   // (or the baseline image, if Compare() was not called yet), based on output

--- a/guetzli/guetzli.cc
+++ b/guetzli/guetzli.cc
@@ -34,7 +34,7 @@ constexpr int kDefaultJPEGQuality = 95;
 
 // An upper estimate of memory usage of Guetzli. The bound is
 // max(kLowerMemusaeMB * 1<<20, pixel_count * kBytesPerPixel)
-constexpr int kBytesPerPixel = 200;
+constexpr int kBytesPerPixel = 125;
 constexpr int kLowestMemusageMB = 100; // in MB
 
 constexpr int kDefaultMemlimitMB = 6000; // in MB

--- a/guetzli/processor.cc
+++ b/guetzli/processor.cc
@@ -719,6 +719,8 @@ void Processor::SelectFrequencyMasking(const JPEGData& jpg, OutputImage* img,
           break;
         }
       }
+      size_t global_order_size = global_order.size();
+      std::vector<std::pair<int, float>>().swap(global_order);
 
       for (int i = 0; i < num_blocks; ++i) {
         max_block_error[i] += block_weight[i] * val_threshold * direction;
@@ -737,7 +739,7 @@ void Processor::SelectFrequencyMasking(const JPEGData& jpg, OutputImage* img,
                   "Blocks[%zd/%d/%d] ValThres[%.4f] Out[%7zd] EstErr[%.2f%%]",
                   stats_->counters[kNumItersCnt], img->FrameTypeStr().c_str(),
                   comp_mask, direction > 0 ? "up" : "down", changed_coeffs,
-                  global_order.size(), changed_blocks.size(),
+                  global_order_size, changed_blocks.size(),
                   blocks_to_change, num_blocks, val_threshold,
                   encoded_jpg.size(),
                   100.0 - (100.0 * est_jpg_size) / encoded_jpg.size());

--- a/guetzli/processor.cc
+++ b/guetzli/processor.cc
@@ -398,6 +398,7 @@ void Processor::ComputeBlockZeroingOrder(
               return a.second < b.second; });
   coeff_t processed_block[kBlockSize];
   memcpy(processed_block, block, sizeof(processed_block));
+  comparator_->SwitchBlock(block_x, block_y, factor_x, factor_y);
   while (!input_order.empty()) {
     float best_err = 1e17f;
     int best_i = 0;
@@ -420,7 +421,7 @@ void Processor::ComputeBlockZeroingOrder(
           int block_xx = block_x * factor_x + ix;
           int block_yy = block_y * factor_y + iy;
           if (8 * block_xx < img->width() && 8 * block_yy < img->height()) {
-            float err = comparator_->CompareBlock(*img, block_xx, block_yy);
+            float err = comparator_->CompareBlock(*img, ix, iy);
             max_err = std::max(max_err, err);
           }
         }
@@ -881,7 +882,7 @@ bool Process(const Params& params, ProcessStats* stats,
   std::unique_ptr<ButteraugliComparator> comparator;
   if (jpg.width >= 32 && jpg.height >= 32) {
     comparator.reset(
-        new ButteraugliComparator(jpg.width, jpg.height, rgb,
+        new ButteraugliComparator(jpg.width, jpg.height, &rgb,
                                   params.butteraugli_target, stats));
   }
   bool ok = ProcessJpegData(params, jpg, comparator.get(), &out, stats);
@@ -905,7 +906,7 @@ bool Process(const Params& params, ProcessStats* stats,
   std::unique_ptr<ButteraugliComparator> comparator;
   if (jpg.width >= 32 && jpg.height >= 32) {
     comparator.reset(
-        new ButteraugliComparator(jpg.width, jpg.height, rgb,
+        new ButteraugliComparator(jpg.width, jpg.height, &rgb,
                                   params.butteraugli_target, stats));
   }
   bool ok = ProcessJpegData(params, jpg, comparator.get(), &out, stats);

--- a/guetzli/processor.cc
+++ b/guetzli/processor.cc
@@ -550,6 +550,7 @@ void Processor::SelectFrequencyMasking(const JPEGData& jpg, OutputImage* img,
   const int num_blocks = block_width * block_height;
 
   std::vector<std::vector<CoeffData> > orders(num_blocks);
+  comparator_->StartBlockComparisons();
   for (int block_y = 0, block_ix = 0; block_y < block_height; ++block_y) {
     for (int block_x = 0; block_x < block_width; ++block_x, ++block_ix) {
       coeff_t block[kBlockSize] = { 0 };
@@ -572,6 +573,7 @@ void Processor::SelectFrequencyMasking(const JPEGData& jpg, OutputImage* img,
                                &orders[block_ix]);
     }
   }
+  comparator_->FinishBlockComparisons();
 
   std::vector<JpegHistogram> ac_histograms(ncomp);
   int jpg_header_size, dc_size;

--- a/third_party/butteraugli/butteraugli/butteraugli.cc
+++ b/third_party/butteraugli/butteraugli/butteraugli.cc
@@ -1451,10 +1451,8 @@ void Mask(const std::vector<std::vector<float> > &xyb0,
           std::vector<std::vector<float> > *mask_dc) {
    PROFILER_FUNC;
   mask->resize(3);
-  mask_dc->resize(3);
   for (int i = 0; i < 3; ++i) {
     (*mask)[i].resize(xsize * ysize);
-    (*mask_dc)[i].resize(xsize * ysize);
   }
   DiffPrecompute(xyb0, xyb1, xsize, ysize, mask);
   for (int i = 0; i < 3; ++i) {
@@ -1471,6 +1469,10 @@ void Mask(const std::vector<std::vector<float> > &xyb0,
   static const double w11 = 22.9455222245;
   static const double w22 = 503.962310606;
 
+  mask_dc->resize(3);
+  for (int i = 0; i < 3; ++i) {
+    (*mask_dc)[i].resize(xsize * ysize);
+  }
   for (size_t y = 0; y < ysize; ++y) {
     for (size_t x = 0; x < xsize; ++x) {
       const size_t idx = y * xsize + x;

--- a/third_party/butteraugli/butteraugli/butteraugli.cc
+++ b/third_party/butteraugli/butteraugli/butteraugli.cc
@@ -1037,11 +1037,11 @@ void ButteraugliComparator::DiffmapOpsinDynamicsImage(
     assert(xyb0[i].size() == num_pixels_);
     assert(xyb1[i].size() == num_pixels_);
   }
+  std::vector<float> edge_detector_map(3 * res_xsize_ * res_ysize_);
+  EdgeDetectorMap(xyb0, xyb1, &edge_detector_map);
   std::vector<float> block_diff_dc(3 * res_xsize_ * res_ysize_);
   std::vector<float> block_diff_ac(3 * res_xsize_ * res_ysize_);
-  std::vector<float> edge_detector_map(3 * res_xsize_ * res_ysize_);
   BlockDiffMap(xyb0, xyb1, &block_diff_dc, &block_diff_ac);
-  EdgeDetectorMap(xyb0, xyb1, &edge_detector_map);
   EdgeDetectorLowFreq(xyb0, xyb1, &block_diff_ac);
   {
     std::vector<std::vector<float> > mask_xyb(3);


### PR DESCRIPTION
This PR continues to address #11

Peak memory usage of the ~1MP station.png file from the test corpus went from 161 MiB to 110 MiB.