### PR TITLE
Bugfix: Check size of data read

### DIFF
--- a/guetzli/guetzli.cc
+++ b/guetzli/guetzli.cc
@@ -176,6 +176,8 @@ std::string ReadFileOrDie(const char* filename) {
   std::unique_ptr<char[]> buf(new char[buffer_size]);
   while (!feof(f)) {
     size_t read_bytes = fread(buf.get(), sizeof(char), buffer_size, f);
+    if (read_bytes == 0)
+       break;
     if (ferror(f)) {
       perror("fread");
       exit(1);


### PR DESCRIPTION
This is a bugfix for issue  #166 and other possible problems. 
Added code to check the size of data read with `fread()`. In general, it is not a good idea to rely on the feof status of a file before of read it.