### PR TITLE
Reduce memory usage of guetzli by about 16 bytes/pixel.

### DIFF
--- a/guetzli/butteraugli_comparator.h
+++ b/guetzli/butteraugli_comparator.h
@@ -71,7 +71,6 @@ class ButteraugliComparator : public Comparator {
   int block_y_;
   int factor_x_;
   int factor_y_;
-  std::vector<std::vector<float>> rgb_linear_pregamma_;
   std::vector<std::vector<float>> mask_xyz_;
   std::vector<std::vector<std::vector<float>>> per_block_pregamma_;
   ::butteraugli::ButteraugliComparator comparator_;

--- a/guetzli/guetzli.cc
+++ b/guetzli/guetzli.cc
@@ -35,7 +35,7 @@ constexpr int kDefaultJPEGQuality = 95;
 
 // An upper estimate of memory usage of Guetzli. The bound is
 // max(kLowerMemusaeMB * 1<<20, pixel_count * kBytesPerPixel)
-constexpr int kBytesPerPixel = 125;
+constexpr int kBytesPerPixel = 110;
 constexpr int kLowestMemusageMB = 100; // in MB
 
 constexpr int kDefaultMemlimitMB = 6000; // in MB

--- a/guetzli/processor.cc
+++ b/guetzli/processor.cc
@@ -141,8 +141,6 @@ void Processor::MaybeOutput(const std::string& encoded_jpg) {
   GUETZLI_LOG(stats_, " Score[%.4f]", score);
   if (score < final_output_->score || final_output_->score < 0) {
     final_output_->jpeg_data = encoded_jpg;
-    final_output_->distmap = comparator_->distmap();
-    final_output_->distmap_aggregate = comparator_->distmap_aggregate();
     final_output_->score = score;
     GUETZLI_LOG(stats_, " (*)");
   }
@@ -823,9 +821,6 @@ bool Processor::ProcessJpegData(const Params& params, const JPEGData& jpg_in,
   if (comparator_ == nullptr) {
     GUETZLI_LOG(stats, " <image too small for Butteraugli>\n");
     final_output_->jpeg_data = encoded_jpg;
-    final_output_->distmap =
-        std::vector<float>(jpg_in.width * jpg_in.height, 0.0);
-    final_output_->distmap_aggregate = 0;
     final_output_->score = encoded_jpg.size();
     // Butteraugli doesn't work with images this small.
     return true;

--- a/guetzli/processor.h
+++ b/guetzli/processor.h
@@ -42,8 +42,6 @@ bool Process(const Params& params, ProcessStats* stats,
 
 struct GuetzliOutput {
   std::string jpeg_data;
-  std::vector<float> distmap;
-  double distmap_aggregate;
   double score;
 };
 

--- a/third_party/butteraugli/butteraugli/butteraugli.cc
+++ b/third_party/butteraugli/butteraugli/butteraugli.cc
@@ -1023,14 +1023,14 @@ void CalculateDiffmap(const size_t xsize, const size_t ysize,
 }
 
 void ButteraugliComparator::DiffmapOpsinDynamicsImage(
-    const std::vector<std::vector<float>> &xyb0_arg,
+    std::vector<std::vector<float>> &xyb0,
     std::vector<std::vector<float>> &xyb1,
     std::vector<float> &result) {
   if (xsize_ < 8 || ysize_ < 8) return;
-  auto xyb0 = xyb0_arg;
   {
+    auto xyb0_c = xyb0;
     auto xyb1_c = xyb1;
-    MaskHighIntensityChange(xsize_, ysize_, xyb0_arg, xyb1_c, xyb0, xyb1);
+    MaskHighIntensityChange(xsize_, ysize_, xyb0_c, xyb1_c, xyb0, xyb1);
   }
   assert(8 <= xsize_);
   for (int i = 0; i < 3; i++) {

--- a/third_party/butteraugli/butteraugli/butteraugli.h
+++ b/third_party/butteraugli/butteraugli/butteraugli.h
@@ -45,8 +45,8 @@ class ButteraugliComparator {
 
   // Computes the butteraugli map between xyb0 and xyb1 and updates result.
   // Both xyb0 and xyb1 are in opsin-dynamics space.
-  // NOTE: The xyb1 image is mutated by this function in-place.
-  void DiffmapOpsinDynamicsImage(const std::vector<std::vector<float>> &xyb0,
+  // NOTE: The xyb0 and xyb1 images are mutated by this function in-place.
+  void DiffmapOpsinDynamicsImage(std::vector<std::vector<float>> &xyb0,
                                  std::vector<std::vector<float>> &xyb1,
                                  std::vector<float> &result);
 


### PR DESCRIPTION
Peak memory usage of the ~1MP station.png file from the test corpus
went from 111 MiB to 94 MiB.

The memory reduction is achieved by:
 (1) not storing the opsin dynamic image of the original, since it turns
     out that recomputing it is not significant, compared to other operations
     in butteraugli,
 (2) removing the distance map from GuetzliOutput, since it is not used
     afterwards, and
 (3) clearing the previous values from distance map before starting
     butteraugli calculations.

I checked that the golden test passes.