### PR TITLE
g++ does not come with fedora by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ sequential (nonprogressive) JPEGs due to faster decompression speeds they offer.
     package manager, install development versions of the packages if the
     distinction exists.
     *   On Ubuntu, do `apt-get install libpng-dev`.
-    *   On Fedora, do `dnf install libpng-devel`. 
+    *   On Fedora, do `dnf install libpng-devel gcc-c++`. 
     *   On Arch Linux, do `pacman -S libpng`.
     *   On Alpine Linux, do `apk add libpng-dev`.
 3.  Run `make` and expect the binary to be created in `bin/Release/guetzli`.


### PR DESCRIPTION
I've tried it on fedora and it generates a working build.